### PR TITLE
Add: Implement enrolled courses API and refactor TemplateTopic compon…

### DIFF
--- a/src/app/api/course/enrolled/route.ts
+++ b/src/app/api/course/enrolled/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+export async function GET() {
+    const BASEURL = process.env.BASEURL;
+    const cookiesStore = await cookies();
+    const accessToken = cookiesStore.get("accessToken")?.value;
+
+    try {
+        const response = await fetch(`${BASEURL}/course/enrolled`, {
+            method: "GET",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${accessToken}`
+            }
+        });
+
+        if (!response.ok) {
+            return NextResponse.error();
+        }
+        const data = await response.json();
+        return NextResponse.json(data.data);
+    } catch (error) {
+        console.error("Error fetching course:", error);
+        return NextResponse.json(
+            {
+                error: error instanceof Error ? error.message : "Internal server error",
+            },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,21 +1,22 @@
 import LandingPage from "@/components/landingPage/LandingPage";
 import TemplateTopic from "@/components/course/TemplateTopic";
-// import { useGetCourses } from "@/hooks/useGetCourses";
 
-export default function Home() {
+export default function Home() {  
   return (
     <div className="">
       <LandingPage />
 
       <TemplateTopic
-        topic="Featured Courses"
-        description="Discover our handpicked courses setting benchmarks in excellence!"
-        // contents={data}
+        header={{
+          topic: "Featured Courses",
+          description:
+            "Discover our handpicked courses setting benchmarks in excellence!",
+        }}
       />
-      <TemplateTopic
-        topic="Explore Courses"
-        description="Browse through a diverse selection of courses designed to elevate your skills."
-        // contents={data}
+      <TemplateTopic header = {{
+        topic: "Explore Courses",
+        description: "Browse through a diverse selection of courses designed to elevate your skills."
+      }}
       />
     </div>
   );

--- a/src/app/profile/enrolledCourses/page.tsx
+++ b/src/app/profile/enrolledCourses/page.tsx
@@ -1,13 +1,16 @@
 import TemplateTopic from "@/components/course/TemplateTopic";
 import ProfileLayout from "@/components/profile/ProfileLayout";
-import React from "react";
+// import { useGetCourses } from "@/hooks/useGetCourses";
+// import React from "react";
 
-const enrolledCourses = () => {
+const EnrolledCourses = () => {
+  // const responseData = useGetCourses({ url: "/api/course/enrolled" });
+
   return (
     <ProfileLayout>
-      <TemplateTopic topic={"Course Enrolled"} />
+      <TemplateTopic header={{ topic: "Course Enrolled"}} from={'profile'} />
     </ProfileLayout>
   );
 };
 
-export default enrolledCourses;
+export default EnrolledCourses;

--- a/src/components/admin/Sidebar.tsx
+++ b/src/components/admin/Sidebar.tsx
@@ -36,14 +36,18 @@ const Sidebar = () => {
           </div>
           <Link
             href="/admin/courses"
-            className="flex items-center gap-3 text-gray-600 hover:text-purple-600 px-3 py-2 rounded-md"
+            className={
+              "flex items-center gap-3 text-gray-600 hover:text-purple-600 px-3 py-2 rounded-md"
+            }
           >
             <BarChart3 className="h-5 w-5" />
             Course Management
           </Link>
           <Link
             href="/admin/instructors"
-            className="flex items-center gap-3 text-gray-600 hover:text-purple-600 px-3 py-2 rounded-md"
+            className={
+              "flex items-center gap-3 text-gray-600 hover:text-purple-600 px-3 py-2 rounded-md"
+            }
           >
             <Users className="h-5 w-5" />
             Instructor Management
@@ -56,7 +60,9 @@ const Sidebar = () => {
           </div>
           <Link
             href="/admin/reports"
-            className="flex items-center gap-3 text-gray-600 hover:text-purple-600 px-3 py-2 rounded-md"
+            className={
+              "flex items-center gap-3 text-gray-600 hover:text-purple-600 px-3 py-2 rounded-md"
+            }
           >
             <PieChart className="h-5 w-5" />
             Report & Analytics

--- a/src/components/course/TemplateTopic.tsx
+++ b/src/components/course/TemplateTopic.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-// import type { mockCourse } from "@/utilities/mock";
 import CourseCard from "./CourseCard";
 import Link from "next/link";
 import { ChevronRight } from "lucide-react";
@@ -12,9 +11,22 @@ interface TemplateProps {
   description?: string;
 }
 
-const TemplateTopic = ({ topic, description }: TemplateProps) => {
-  const { data: contents, error, loading } = useGetCourses();
-  console.log(contents, "contents from TemplateTopic");
+const TemplateTopic = ({
+  header,
+  from,
+}: {
+  header: TemplateProps;
+  from?: string;
+}) => {
+  const { topic, description } = header;
+  const allcourses = useGetCourses({ url: "/api/course/getCourses" });
+  const enrolledCourses = useGetCourses({ url: "/api/course/enrolled" });
+
+  const courseData =
+    from === "profile" ? enrolledCourses ?? allcourses : allcourses;
+
+  const { data: contents, error, loading } = courseData;
+  console.log(contents, "contents in TemplateTopic");
   const [firstWord, secondWord] = topic.split(" ");
   const isFeatured = firstWord.toLowerCase() === "featured";
 

--- a/src/hooks/useGetCourses.tsx
+++ b/src/hooks/useGetCourses.tsx
@@ -1,10 +1,7 @@
 import { useFetchListData } from "./useFetchData";
 import { course } from "@/types/courses";
 
-export const useGetCourses = () => {
-  const { data, error, loading } = useFetchListData<course>({
-    url: "/api/course/getCourses",
-  });
-
+export const useGetCourses = ({ url }: { url: string }) => {
+  const { data, error, loading } = useFetchListData<course>({ url });
   return { data, error, loading };
 };


### PR DESCRIPTION
This pull request includes several changes aimed at improving the course fetching functionality and updating component structures. The most important changes include adding a new API route for fetching enrolled courses, updating the `TemplateTopic` component to handle different headers and data sources, and modifying the `useGetCourses` hook to accept a URL parameter.

### API and Data Fetching Improvements:

* [`src/app/api/course/enrolled/route.ts`](diffhunk://#diff-ef6ac5b1e03b29be961bd0ca3d43a6631308e332f9e68425d29bef04a1254978R1-R32): Added a new API route to fetch enrolled courses, including error handling and response formatting.

### Component Updates:

* [`src/components/course/TemplateTopic.tsx`](diffhunk://#diff-28b458c51ab5526499f58173e4ebf819a21565dd340880fd4f3c9ec836fe6cecL15-R29): Updated the `TemplateTopic` component to accept a `header` prop and an optional `from` prop to differentiate between all courses and enrolled courses.
* [`src/app/page.tsx`](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL3-R19): Modified the `TemplateTopic` usage to pass the new `header` prop structure.
* [`src/app/profile/enrolledCourses/page.tsx`](diffhunk://#diff-a69e7e25088024908df6e3f87d19a99cc945723146660e10e84ef5f292ce1ebdL3-R16): Updated the enrolled courses page to use the new `TemplateTopic` structure and renamed the component to `EnrolledCourses`.

### Hook Enhancements:

* [`src/hooks/useGetCourses.tsx`](diffhunk://#diff-eeb0c7fb83a66bb74958dc52fe4cf991b1d20d81d13f9e62de2a4ce0749519edL4-R5): Modified the `useGetCourses` hook to accept a URL parameter, allowing for more flexible data fetching.

### Code Formatting:

* [`src/components/admin/Sidebar.tsx`](diffhunk://#diff-70b22707f4093bb24a9b28f2d59bd18f8bed5f3b7137645e35d6db85dc96428dL39-R50): Reformatted the `className` attribute in multiple `Link` components for better readability. [[1]](diffhunk://#diff-70b22707f4093bb24a9b28f2d59bd18f8bed5f3b7137645e35d6db85dc96428dL39-R50) [[2]](diffhunk://#diff-70b22707f4093bb24a9b28f2d59bd18f8bed5f3b7137645e35d6db85dc96428dL59-R65)